### PR TITLE
fix: remove the deprecated force delete flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_endpoint_type"></a> [endpoint\_type](#input\_endpoint\_type) | The type of endpoint to be used for creating keys. Accepts 'public' or 'private' | `string` | `"public"` | no |
-| <a name="input_force_delete"></a> [force\_delete](#input\_force\_delete) | Set to `true` if you wish to force delete the kms key rings, else `false`. | `bool` | `false` | no |
 | <a name="input_instance_id"></a> [instance\_id](#input\_instance\_id) | The KMS instance GUID | `string` | n/a | yes |
 | <a name="input_key_ring_id"></a> [key\_ring\_id](#input\_key\_ring\_id) | The ID that identifies the Key Ring. Each ID is unique within the given KMS instance but is not reserved across the KMS service | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.58.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.69.0, < 2.0.0 |
 
 ### Modules
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -3,8 +3,7 @@
 ##############################################################################
 
 module "kms_key_ring" {
-  source       = "../.."
-  instance_id  = var.existing_kms_instance_guid
-  key_ring_id  = "${var.prefix}-key-ring"
-  force_delete = true # Setting it to true for testing purpose
+  source      = "../.."
+  instance_id = var.existing_kms_instance_guid
+  key_ring_id = "${var.prefix}-key-ring"
 }

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.0"
+      version = "1.69.0"
     }
   }
 }

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.69.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,5 +6,4 @@ resource "ibm_kms_key_rings" "key_ring" {
   endpoint_type = var.endpoint_type
   instance_id   = var.instance_id
   key_ring_id   = var.key_ring_id
-  force_delete  = var.force_delete
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,12 +17,6 @@ variable "instance_id" {
   description = "The KMS instance GUID"
 }
 
-variable "force_delete" {
-  type        = bool
-  description = "Set to `true` if you wish to force delete the kms key rings, else `false`."
-  default     = false
-}
-
 variable "key_ring_id" {
   type        = string
   description = "The ID that identifies the Key Ring. Each ID is unique within the given KMS instance but is not reserved across the KMS service"

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.58.0, < 2.0.0"
+      version = ">= 1.69.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description
The `force_delete` flag has now been deprecated by the provider, removing from the module.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

`force_delete` has been deprecated by the provider and removed from the module, the new default behavior of deleting a key ring is to move keys with state equals to 5 (destroyed) to the default key ring.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
